### PR TITLE
add x0d stripping before pasting with p

### DIFF
--- a/src/perl/confirm-paste
+++ b/src/perl/confirm-paste
@@ -78,7 +78,9 @@ sub key_press {
       $self->tt_paste ($paste);
       $self->leave;
    } elsif ($keysym == 112) { # p
-      $self->tt_paste ($$paste);
+      my $paste = $$paste;
+      $paste =~ s/[\x0d]/ /g;
+      $self->tt_paste ($paste);
       $self->leave;
    } elsif ($keysym == 110) { # n
       $self->leave;


### PR DESCRIPTION
A random suggestion to fix the double newline issue that arises when pasting from DOS style formatted sources.

I'm a cat, so don't be too hard on me if I seem like I don't know what I'm even doing.