### PR TITLE
Makefile.in: set outdir for TIC explicitly

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -69,7 +69,7 @@ all:
 	sed $(SEDREPLACE) <$< | podselect -section "RXVT-UNICODE\/URXVT FREQUENTLY ASKED QUESTIONS" | pod2text >$@
 
 $(srcdir)/etc/rxvt-unicode.termcap: $(srcdir)/etc/rxvt-unicode.terminfo
-	tic -C $< >$@
+	@TIC@ -C $< >$@
 
 tags allbin:
 
@@ -100,8 +100,8 @@ install: all
 	$(INSTALL_DATA) rxvtd.1.man   $(DESTDIR)$(man1dir)/$(RXVTNAME)d.$(man1ext)
 	$(INSTALL_DATA) rxvt.7.man    $(DESTDIR)$(man7dir)/$(RXVTNAME).$(man7ext)
 	$(INSTALL_DATA) rclock.1.man  $(DESTDIR)$(man1dir)/urclock.$(man1ext)
-	@TIC@ -x $(srcdir)/etc/rxvt-unicode.terminfo || \
-           @TIC@ $(srcdir)/etc/rxvt-unicode.terminfo
+	@TIC@ -x $(srcdir)/etc/rxvt-unicode.terminfo -o $(DESTDIR)$(datadir)/terminfo || \
+           @TIC@ $(srcdir)/etc/rxvt-unicode.terminfo -o -o $(DESTDIR)$(datadir)/terminfo
 
 distdepend: alldoc
 


### PR DESCRIPTION
When doing cross-compile, native tic's TERMINFO usually set as a native dir, which could not the target install dir, which will cause rxvt-unicode terminfo will be wrongly installed. set the outdir explicitly to install them to correct dir.